### PR TITLE
Python 2 compatability

### DIFF
--- a/mutube/compat.py
+++ b/mutube/compat.py
@@ -1,0 +1,13 @@
+""" compat
+Variations in importing for python 2/ 3
+"""
+
+try: # python 3.x
+    from urllib.request import urlopen
+    from urllib.parse import urlparse, parse_qs
+    from urllib.error import HTTPError
+
+except(ImportError): # python 2.x
+    from urllib2 import urlopen, urlparse, HTTPError
+    from urlparse import parse_qs
+

--- a/mutube/compat.py
+++ b/mutube/compat.py
@@ -8,6 +8,6 @@ try: # python 3.x
     from urllib.error import HTTPError
 
 except(ImportError): # python 2.x
-    from urllib2 import urlopen, urlparse, HTTPError
-    from urlparse import parse_qs
+    from urllib2 import urlopen, HTTPError
+    from urlparse import parse_qs, urlparse
 

--- a/mutube/scraper.py
+++ b/mutube/scraper.py
@@ -3,9 +3,7 @@
 Scrape YouTube links from 4chan threads.
 """
 import json                                                                     
-from urllib.request import urlopen
-from urllib.parse import urlparse, parse_qs
-from urllib.error import HTTPError
+from .compat import HTTPError, parse_qs, urlopen, urlparse
 from bs4 import BeautifulSoup
 
 


### PR DESCRIPTION
`urllib` has changed in structure between Python 2 and 3, which needs to be reflected in the code to make mutube compatible with Python 2.x.