### PR TITLE
Seperate credentials

### DIFF
--- a/examples/daily_daily.py
+++ b/examples/daily_daily.py
@@ -3,7 +3,7 @@
 This script automatically generates daily playlists of YouTube links posted
 to the /daily/ general threads on 4chan's /mu/.
 """
-from mutube import Scraper, Playlister, Mutuber
+from mutube import Scraper, Playlister, Mutuber, ResourceBuilder
 
 def first_word_matcher(subject, general):
     """ Determine whether first word in `subject` == `general`.
@@ -14,14 +14,13 @@ def first_word_matcher(subject, general):
     return True if subject.split('-')[0].strip() == general else False
 
 if __name__ == "__main__":
-    # Initialise objects 
+    # Initialise objects
     scraper = Scraper(board='mu',
                       matching_func=first_word_matcher, # custom matching 
-                      general="/daily/") # argument to matching function
-    playlister = Playlister(
-                    prefix='DAYLIST',
-                    time_format='%A %d.%m.%Y', # Thursday 23.06.2016
-                    client_json='client_id.json')
+                      general="/daily/") # argument to matching function 
+    resource = ResourceBuilder.from_client_credentials_file('client_id.json') 
+    playlister = Playlister(resource=resource, prefix='DAYLIST',
+                            time_format='%A %d.%m.%Y') # e.g. Thursday 23.06.2016
     mutuber = Mutuber(scraper, playlister,
                       current_only=True) # repost between different playlists
     

--- a/examples/metal_monthly.py
+++ b/examples/metal_monthly.py
@@ -3,15 +3,15 @@
 This script automatically generates monthly playlists of YouTube links posted
 to the /metal/ general threads on 4chan's /mu/.
 """
-from mutube import Scraper, Playlister, Mutuber
+from mutube import Scraper, Playlister, Mutuber, ResourceBuilder
 
 if __name__ == "__main__":
     # Initialise mutuber object                                             
     scraper = Scraper(board='mu', subjects=['/metal/',
                                             '/metal/ - Metal General'])
-    playlister = Playlister(prefix = r'\m/',
+    resource = ResourceBuilder.from_user_credentials_file('client_id.json')
+    playlister = Playlister(resource=resource, prefix=r'\m/',
                             time_format = '%b %Y') # i.e. "Nov 2016"
-                            
     mutuber = Mutuber(scraper, playlister)
     mutuber.run_forever()
 

--- a/mutube/__init__.py
+++ b/mutube/__init__.py
@@ -1,4 +1,5 @@
 from .exceptions import NoTag, NoPlaylist, BadVideo
 from .scraper import Scraper
 from .playlister import Playlister, encode_tag, decode_tag, HttpError
-from mutuber import Mutuber
+from .resource_builder import ResourceBuilder
+from .mutuber import Mutuber

--- a/mutube/resource_builder.py
+++ b/mutube/resource_builder.py
@@ -1,0 +1,82 @@
+""" resource builder
+
+Create resource to interact with YouTube API.
+"""
+import httplib2
+import json
+from apiclient.discovery import build
+from apiclient.errors import HttpError
+from oauth2client.client import flow_from_clientsecrets
+from oauth2client.file import Storage
+from oauth2client.tools import run_flow
+
+# YouTube API information
+YOUTUBE_READ_WRITE_SCOPE = "https://www.googleapis.com/auth/youtube"
+YOUTUBE_API_SERVICE_NAME = "youtube"
+YOUTUBE_API_VERSION = "v3"
+
+class ResourceBuilder(object):
+    """ Factory building resource object to make YouTube read/write requests. """
+    
+    @classmethod
+    def from_credentials_object(cls, credentials):
+        """ Return a resource object from a credentials object.
+        Args:
+            credentials ::: `oauth2client.client.Credentials` instance
+        Returns:
+            youtube ::: YouTube `apiclient.discovery.Resource` instance
+       """
+        # Build YouTube resource object
+        youtube = build(YOUTUBE_API_SERVICE_NAME, YOUTUBE_API_VERSION,
+                        http=credentials.authorize(httplib2.Http()))
+        return youtube
+
+    @classmethod
+    def from_user_credentials_file(cls, user_credentials_fname):
+        """ Return a resource object from file containing user credentials.
+        Args:
+            user_credentials_fname ::: path to .json file to read
+                                       contains OAuth 2.0 user credentials
+                                       usually created by auth flow, see
+                                       `from_client_credentials_fname` method
+        Returns:
+            youtube ::: YouTube `apiclient.discovery.Resource` instance
+        """
+        credentials = Storage(user_credentials_fname).get()
+        return cls.from_credentials_object(credentials)
+
+    @classmethod
+    def from_client_credentials_file(cls, client_credentials_fname,
+                                     user_credentials_fname=None):
+        """ Request authorisation for an app client, returning resource object.
+        Args:
+            client_credentials_fname ::: path to .json file to read
+                                         contains OAuth 2.0 client credentials,
+                                         download from:
+                                         https://console.developers.google.com/
+            user_credentials_fname ::: path to .json file to write to
+        Returns: 
+            youtube ::: YouTube `apiclient.discovery.Resource` instance
+        Creates:
+            <user_credentials_fname> ::: .json file containing user credentials
+
+        Note that this requires human interaction, and will not work in a
+        jupyter notebook.
+        """
+        
+        # Build OAuth flow object
+        flow = flow_from_clientsecrets(filename=client_credentials_fname,
+                                       scope=YOUTUBE_READ_WRITE_SCOPE)
+        
+        if user_credentials_fname is None: # autoname credentials file            
+            with open(client_credentials_fname) as o: # extract project_id
+                project_id = json.load(o)['installed']['project_id']
+            user_credentials_fname = "{}-oauth2.json".format(project_id)
+
+        # Load/create credentials
+        storage = Storage(user_credentials_fname)
+        credentials = storage.get()
+        if credentials is None or credentials.invalid: 
+            credentials = run_flow(flow, storage) # request authorisation
+        
+        return cls.from_credentials_object(credentials)

--- a/mutube/resource_builder.py
+++ b/mutube/resource_builder.py
@@ -20,7 +20,7 @@ class ResourceBuilder(object):
     
     @classmethod
     def from_credentials_object(cls, credentials):
-        """ Return a resource object from a credentials object.
+        """ Return a resource object from a user credentials object.
         Args:
             credentials ::: `oauth2client.client.Credentials` instance
         Returns:
@@ -60,8 +60,9 @@ class ResourceBuilder(object):
         Creates:
             <user_credentials_fname> ::: .json file containing user credentials
 
-        Note that this requires human interaction, and will not work in a
-        jupyter notebook.
+        This method will try to open a link in the browser requesting that the
+        user sign in to YouTube and authorise the app to modify data.
+        This will not work if run inside of a Jupyter Notebook.
         """
         
         # Build OAuth flow object


### PR DESCRIPTION
All code relating to the construction of the `Resource` object to interact with the YouTube API, including the app authorisation flow and subsequent reading of user credentials, is now handled by the `ResourceBuilder` factory class in the new `resource_builder` module. The `Playlister` now simply takes this `Resource` instance on initialisation.